### PR TITLE
Fix Cap LoRa 1262 invalid initialization

### DIFF
--- a/variants/m5stack_cardputer/M5CardputerBoard.h
+++ b/variants/m5stack_cardputer/M5CardputerBoard.h
@@ -11,15 +11,10 @@
 class M5CardputerBoard : public ESP32Board {
 public:
   void begin() {
-    // Step 1: Enable power to I/O expander on LoRa Cap (GPIO 46)
-    pinMode(46, OUTPUT);
-    digitalWrite(46, HIGH);
-    delay(100);  // Give I/O expander time to power up
-
-    // Step 2: Initialize main I2C (SDA=2, SCL=1) before M5Cardputer keyboard init
+    // Step 1: Initialize main I2C (SDA=2, SCL=1) before M5Cardputer keyboard init
     ESP32Board::begin();
 
-    // Step 3: Initialize M5Cardputer hardware with keyboard enabled
+    // Step 2: Initialize M5Cardputer hardware with keyboard enabled
     auto cfg = M5.config();
     cfg.clear_display = true;
     cfg.internal_imu = false;  // No IMU on Cardputer-Adv
@@ -29,13 +24,6 @@ public:
     M5Cardputer.begin(cfg, true);  // true = enable keyboard
     delay(100);
     M5Cardputer.Keyboard.begin();
-
-    M5.In_I2C.writeRegister8(0x43, 0x03, 0x00, 100000);  
-    delay(10);
-    M5.In_I2C.writeRegister8(0x43, 0x01, 0xFF, 100000);  
-    delay(200); 
-
-    Serial.println("LoRa Cap I/O expander (PI4IOE at 0x43 on SDA=8,SCL=9) configured");
 
     Serial.println("M5Stack Cardputer-Adv initialized");
     Serial.print("Battery voltage: ");

--- a/variants/m5stack_cardputer/target.cpp
+++ b/variants/m5stack_cardputer/target.cpp
@@ -2,6 +2,7 @@
 #include "target.h"
 
 M5CardputerBoard board;
+m5::PI4IOE5V6408_Class ioe(0x43, 400000, &m5::In_I2C);;
 
 static SPIClass spi;
 RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi, SPISettings());
@@ -189,6 +190,13 @@ SensorManager sensors;
 bool radio_init() {
   fallback_clock.begin();
   rtc_clock.begin(Wire);
+
+  if (ioe.begin()) {
+    Serial.printf("Using Cap LoRa-1262\n");
+    ioe.setDirection(0, true);      // Output
+    ioe.setHighImpedance(0, false); // Disable high-impedance so pin can actually drive
+    ioe.digitalWrite(0, true);      // High Level
+  }
   
   // Hardware reset sequence for LoRa module
   // This ensures proper initialization even if module is connected after power-on

--- a/variants/m5stack_cardputer/target.h
+++ b/variants/m5stack_cardputer/target.h
@@ -5,6 +5,7 @@
 #include <helpers/radiolib/RadioLibWrappers.h>
 #include <helpers/radiolib/CustomSX1262Wrapper.h>
 #include <M5CardputerBoard.h>
+#include <utility/PI4IOE5V6408_Class.hpp>
 #include <helpers/AutoDiscoverRTCClock.h>
 #include <helpers/SensorManager.h>
 #ifdef HAS_GPS
@@ -39,6 +40,8 @@ public:
 extern M5CardputerBoard board;
 extern WRAPPER_CLASS radio_driver;
 extern AutoDiscoverRTCClock rtc_clock;
+extern m5::PI4IOE5V6408_Class ioe;
+
 #ifdef HAS_GPS
 extern CardputerSensorManager sensors;
 #else


### PR DESCRIPTION
Hello. Current version does not initialize LoRa Cap correctly. +3.3v not is not present on "SW" pin (io expander P0) of "Stamp LoRa-1262 Mini".

## 1.

```c
    // Step 1: Enable power to I/O expander on LoRa Cap (GPIO 46)
    pinMode(46, OUTPUT);
    digitalWrite(46, HIGH);
    delay(100);  // Give I/O expander time to power up
```
GPIO46 not goes to IO expander, it goes to output of audio codec

<img width="726" height="574" alt="vivaldi_o4uEAZUMCU" src="https://github.com/user-attachments/assets/512d00a5-fde2-4c25-80f9-6cc812035e79" />

## 2.

```c
M5.In_I2C.writeRegister8(0x43, 0x03, 0x00, 100000);  
delay(10);
M5.In_I2C.writeRegister8(0x43, 0x01, 0xFF, 100000);  
```

Both commands are invalid.

0x03 - Set direction. "Output" for P0 is 0x01.
0x01 - Is "ID" register. It should not be written with 0xFF.

Correct sequence is

```c
M5.In_I2C.writeRegister8(0x43, 0x03, 0x01, 100000); // P0 Direction output
M5.In_I2C.writeRegister8(0x43, 0x07, 0x00, 100000); // P0 Disable high-impedance so pin can actually drive
M5.In_I2C.writeRegister8(0x43, 0x05, 0x01, 100000); // P0 High Level
```

Or you just can use M5's PI4IOE5V6408_Class.


https://docs.m5stack.com/en/arduino/projects/cap/cap_lora868#31-lora-usage-example