### PR TITLE
Fix: stack smashing reboot loop when >64 contacts are stored

### DIFF
--- a/examples/companion_radio/ui-keyboard/UITask.cpp
+++ b/examples/companion_radio/ui-keyboard/UITask.cpp
@@ -333,9 +333,9 @@ void UITask::renderContactList() {
     int num_contacts = the_mesh.getNumContacts();
     
     // Filter contacts by search term
-    int filtered_indices[64];
+    int filtered_indices[MAX_CONTACTS];
     int filtered_count = 0;
-    
+
     if (_search_filter_length > 0) {
         for (int i = 0; i < num_contacts; i++) {
             ContactInfo contact;
@@ -351,7 +351,7 @@ void UITask::renderContactList() {
                     lower_filter[j] = tolower(_search_filter[j]);
                     lower_filter[j+1] = '\0';
                 }
-                if (strstr(lower_name, lower_filter) != nullptr) {
+                if (strstr(lower_name, lower_filter) != nullptr && filtered_count < MAX_CONTACTS) {
                     filtered_indices[filtered_count++] = i;
                 }
             }
@@ -359,10 +359,10 @@ void UITask::renderContactList() {
         num_contacts = filtered_count;
     } else {
         // No filter - show all
-        for (int i = 0; i < num_contacts; i++) {
+        for (int i = 0; i < num_contacts && i < MAX_CONTACTS; i++) {
             filtered_indices[i] = i;
         }
-        filtered_count = num_contacts;
+        filtered_count = num_contacts < MAX_CONTACTS ? num_contacts : MAX_CONTACTS;
     }
     
     if (num_contacts == 0) {

--- a/variants/m5stack_cardputer/platformio.ini
+++ b/variants/m5stack_cardputer/platformio.ini
@@ -36,6 +36,7 @@ build_flags =
   -D PIN_BOARD_SDA=2
   -D PIN_BOARD_SCL=1
   -D PIN_VBAT_READ=10   ; Battery voltage ADC
+  -D CONFIG_ARDUINO_LOOP_STACK_SIZE=16384
 build_src_filter = ${esp32_base.build_src_filter}
   +<../variants/m5stack_cardputer>
   -<../variants/m5stack_cardputer/test_main.cpp>

--- a/variants/m5stack_cardputer/target.cpp
+++ b/variants/m5stack_cardputer/target.cpp
@@ -1,5 +1,8 @@
 #include <Arduino.h>
 #include "target.h"
+#ifdef HAS_GPS
+#include "../../examples/companion_radio/NodePrefs.h"
+#endif
 
 M5CardputerBoard board;
 
@@ -147,23 +150,6 @@ bool CardputerSensorManager::setSettingValue(const char* name, const char* value
     
     // Sync with NodePrefs
     if (_node_prefs) {
-      struct NodePrefs { 
-        uint8_t airtime_factor;
-        char node_name[32];
-        float freq; uint8_t sf; uint8_t cr;
-        uint8_t multi_acks;
-        uint8_t manual_add_contacts;
-        float bw;
-        uint8_t tx_power_dbm;
-        uint8_t telemetry_mode_base;
-        uint8_t telemetry_mode_loc;
-        uint8_t telemetry_mode_env;
-        uint8_t rx_delay_base;
-        uint32_t ble_pin;
-        uint8_t advert_loc_policy;
-        uint8_t buzzer_quiet;
-        uint8_t gps_enabled;
-      };
       NodePrefs* prefs = (NodePrefs*)_node_prefs;
       prefs->gps_enabled = should_enable ? 1 : 0;
       Serial.printf("[GPS] Updated NodePrefs: gps_enabled=%d\n", prefs->gps_enabled);


### PR DESCRIPTION
## Problem

The device enters a permanent reboot loop with `Stack smashing protect failure!` in the serial monitor. The crash appears immediately after boot, always at the same point in the log:

```
[GPS] Restoring GPS state from NodePrefs: DISABLED

Stack smashing protect failure!
Backtrace: 0x403780b6:... 0x42008e0b:... 0x4200c6c5:... |<-CORRUPTED
Rebooting...
```

## Root cause

**Buffer overflow in `renderContactList()`** (`UITask.cpp` line 336):

```cpp
int filtered_indices[64];   // ← array holds only 64 elements
// ...
for (int i = 0; i < num_contacts; i++) {
    filtered_indices[i] = i; // ← writes up to MAX_CONTACTS (200) — OVERFLOW
}
```

`MAX_CONTACTS` is 200, but the array was sized at 64. Any device with more than 64 stored contacts (carried over from a previous firmware) would write 136 extra `int` values past the end of the array, smashing the GCC stack canary and triggering a hard reboot.

The backtrace was decoded with `xtensa-esp32s3-elf-addr2line` against the built ELF:
- `0x42008e0b` → `UITask::renderContactList()` (closing brace — canary check fires here)
- `0x4200c6c5` → `UITask::loop()` (caller)
- `0x42007441` → `loop()` in `main.cpp`

`setup()` completes successfully; the crash happens on the very first `loop()` iteration when `renderContactList()` tries to render the contact list.

## Fix

### 1. `renderContactList()` — fix the buffer overflow

Grow the array to `MAX_CONTACTS` and add bounds guards in both the filtered and unfiltered code paths so the array can never be overrun regardless of how many contacts are stored.

### 2. Arduino loop task stack — `platformio.ini`

Raise the loop task stack from the default **8 KB** to **16 KB** via `CONFIG_ARDUINO_LOOP_STACK_SIZE=16384`. The call chain `setup()` → BLE init → NVS/Preferences → M5Stack init consumes significantly more than 8 KB and was itself on the edge of overflowing before the buffer-overflow bug dominated.

### 3. `target.cpp` — remove stale inline `NodePrefs` redefinition

The `setSettingValue()` GPS sync code contained a hand-rolled local `NodePrefs` struct with wrong field types (`uint8_t airtime_factor` / `uint8_t rx_delay_base` instead of `float`). While alignment padding caused `gps_enabled` to land at the same offset by coincidence, the mismatch was a latent correctness bug and a maintenance hazard. Replaced with a direct include of `NodePrefs.h`.

## Test plan

- [x] Firmware builds cleanly (`pio run -e M5stack_cardputer_cap_lora1262_companion`)
- [x] Flashed onto device — no reboot loop, device runs main loop normally (serial shows continuous `RadioLibWrapper: noise_floor` output)
- [x] `Stack smashing protect failure!` no longer appears in serial output

🤖 Generated with [Claude Code](https://claude.com/claude-code)